### PR TITLE
Fix parsing exponential notation in NNDC web page

### DIFF
--- a/nuclear/io/nndc/parsers.py
+++ b/nuclear/io/nndc/parsers.py
@@ -7,24 +7,25 @@ import numpy as np
 
 
 def uncertainty_parser(unc_raw_str, split_unc_symbol='%'):
-        unc_raw_str = unc_raw_str.lower()
+    unc_raw_str = unc_raw_str.replace('×10+', 'e+')
+    unc_raw_str = unc_raw_str.lower()
 
-        value_unc_pair = [item.strip()
-                      for item in unc_raw_str.split(split_unc_symbol)]
+    value_unc_pair = [item.strip()
+                  for item in unc_raw_str.split(split_unc_symbol)]
 
-        if len(value_unc_pair) == 1:  # if no uncertainty given
-            return float(value_unc_pair[0]), np.nan
-        else:
-            value, unc = value_unc_pair[:2]  # limit to two
-        if unc == "" or unc == "?":  # if uncertainty_str is empty or unknown
-            unc = np.nan
-        if "e" in value:
-            exp_pos = value.find("e")
-            unc_str = value[:exp_pos] + f"({unc})" + value[exp_pos:]
-        else:
-            unc_str = value + f"({unc})"
-        parsed_uncertainty = ufloat_fromstr(unc_str)
-        return parsed_uncertainty.nominal_value, parsed_uncertainty.std_dev
+    if len(value_unc_pair) == 1:  # if no uncertainty given
+        return float(value_unc_pair[0]), np.nan
+    else:
+        value, unc = value_unc_pair[:2]  # limit to two
+    if unc == "" or unc == "?":  # if uncertainty_str is empty or unknown
+        unc = np.nan
+    if "e" in value:
+        exp_pos = value.find("e")
+        unc_str = value[:exp_pos] + f"({unc})" + value[exp_pos:]
+    else:
+        unc_str = value + f"({unc})"
+    parsed_uncertainty = ufloat_fromstr(unc_str)
+    return parsed_uncertainty.nominal_value, parsed_uncertainty.std_dev
 
 
 class BaseParser(metaclass=ABCMeta):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->
For some nuclei, such as U-238 (https://www.nndc.bnl.gov/nudat3/decaysearchdirect.jsp?nuc=U238&unc=nds) the half life is given in exponential notation, e.g., '4.468×10+9 y'. The 'x10' should be replaced with 'e' for the string to be parsed as a float value.

**Description**
<!--- Describe your changes in detail -->
This one-line change replaces 'x10+' with 'e+', so that the string can be converted to a float. The indentation of the other code in the uncertainty_parser() function was also modified to be consistent with the code style.

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [x] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/development/documentation_preview.html).
- [x] I have assigned and requested two reviewers for this pull request.
