### PR TITLE
Parser collects annihilation energy gamma-rays

### DIFF
--- a/nuclear/io/nndc/parsers.py
+++ b/nuclear/io/nndc/parsers.py
@@ -37,6 +37,9 @@ class BaseParser(metaclass=ABCMeta):
         return df
 
     def _sanititze_table(self, df):
+        if "dose" in df.columns:
+            del df["dose"]
+
         df.dropna(inplace=True)
 
         if "intensity" in df.columns:
@@ -59,8 +62,6 @@ class BaseParser(metaclass=ABCMeta):
             df.loc[:, "end_point_energy_unc"] = [
                 item[1] for item in end_point_energy]
 
-        if "dose" in df.columns:
-            del df["dose"]
         df['heading'] = self.html_name
         return df
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

**Description**
<!--- Describe your changes in detail -->
Nuclear parser drops NaN values after positron annihilation energies are included

**Motivation and context**
<!--- Why is this change required? What problem does it solve? Link issues here -->
Correct accounting for positron annihilation gamma-rays

**How has this been tested?**
- [ ] Testing pipeline.
- [ ] Other. <!--- please describe how you tested your changes, `pytest` flags used, etc. -->

**Examples**
<!-- If appropriate, link notebooks, screenshots and other demo stuff -->

**Type of change**
<!--- Put an `x` in all the boxes that apply -->
- [ ] Bug fix. <!-- non-breaking change which fixes an issue -->
- [ ] New feature. <!-- non-breaking change which adds functionality -->
- [ ] Breaking change. <!-- fix or feature that would cause existing functionality to not work as expected -->
- [ ] None of the above. <!-- please describe -->

**Checklist**
<!--- Put an `x` in all the boxes that apply -->
- [ ] My change requires a change to the documentation.
    - [ ] I have updated the documentation accordingly.
    - [ ] (optional) I have built the documentation on my fork following [the instructions](https://tardis-sn.github.io/tardis/contributing/development/documentation_guidelines.html#sharing-the-built-documentation-in-your-pr-documentation-preview).
- [ ] I have assigned and requested two reviewers for this pull request.
